### PR TITLE
Replace Python API client with Clojure code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ to [Confluence][confluence].
 
 ## Status
 
-This tool is in very early stage of development, and is probably not suitable for anyone but its
+This tool is in a very early stage of development, and is probably not suitable for anyone but its
 developers to use.
 
-**If** you’re familiar with [Clojure][clojure], [Python][python] (yes, really), Markdown, **and**
+**If** you’re familiar with [Clojure][clojure], Markdown, **and**
 Confluence, **and** you’re comfortable reading the source code thoroughly before usage, **and**
 you’re comfortable running the tool from a Clojure [REPL][repl] — then it *might* not be a terrible
 idea for you to try using this tool.
@@ -19,5 +19,4 @@ idea for you to try using this tool.
 [clojure]: https://clojure.org
 [confluence]: https://www.atlassian.com/software/confluence
 [markdown]: https://en.wikipedia.org/wiki/Markdown
-[python]: https://python.org
 [repl]: https://en.wikipedia.org/wiki/REPL

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,11 @@
                    :sha "2decbbb3ffd8e919c67d29f39ec6d920575f65c3"
                    :tag "0.1.12"
                    :deps/manifest :deps}
-        clj-python/libpython-clj {:mvn/version "1.40"}
+        hato {:git/url "https://github.com/gnarroway/hato"
+              :sha "2417af9c932958ab537c77e01c045e1457bad9e1"
+              :tag "v0.5.0"
+              :deps/manifest :deps}
+        cheshire {:mvn/version "5.10.0"} ; used by hato. multiple deps + no deps.edn
         medley {:git/url "https://github.com/weavejester/medley"
                 :sha "6c79c4cce52b276daa3c2b6eaea78f96904bca56"
                 :tag "1.3.0"}}

--- a/src/md2c8e/anomalies.clj
+++ b/src/md2c8e/anomalies.clj
@@ -1,6 +1,14 @@
 (ns md2c8e.anomalies
   (:require [cognitect.anomalies :as anom]))
 
-(defn anom?
+(defn anom
+  "If the value is a cognitect.anomalies/anomaly, returns the value; otherwise nil."
   [v]
-  (::anom/category v))
+  (and (::anom/category v) v))
+
+(defn fault
+  [first-key first-val & more-kvs]
+  {:pre [(even? (count more-kvs))]}
+  (apply hash-map
+         (concat [::anom/category :fault, first-key first-val]
+                 more-kvs)))

--- a/src/md2c8e/cli.clj
+++ b/src/md2c8e/cli.clj
@@ -1,7 +1,7 @@
 (ns md2c8e.cli
   (:require [clojure.java.io :as io :refer [file]]
             [cognitect.anomalies :as anom]
-            [md2c8e.anomalies :refer [anom?]]
+            [md2c8e.anomalies :refer [anom]]
             [md2c8e.confluence :as confluence :refer [make-client page-exists?!]]
             [md2c8e.core :refer [dir->page-tree publish]]
             [md2c8e.links :refer [replace-links]]
@@ -10,30 +10,33 @@
 
 (defn- summarize
   [ptap source-dir] ; ptap == page-tree-after-publish
-  (let [{:keys [:failed :succeeded :skipped]}
-        (group-by #(cond (anom? %)    :failed
-                         (get % "id") :succeeded ; the results of publish have string keys
-                         :else        :skipped)
+  (let [{:keys [:created :updated :failed :skipped]}
+        (group-by #(cond (anom %)              :failed
+                         (::confluence/page %) (keyword (str (name (::confluence/operation %)) "d"))
+                         :else                 :skipped)
                   ptap)]
     (println (format (str "-------------------\n"
-                          "✅ Succeeded: %s\n"
-                          "🔥 Failed: %s\n"
-                          "⚠️ Skipped: %s")
-                     (count succeeded)
-                     (count failed)
-                     (count skipped)))
+                          "✅ Created: %s\n"
+                          "✅ Updated: %s\n"
+                          "⚠️ Skipped: %s\n"
+                          "🔥 Failed: %s")
+                     (count created)
+                     (count updated)
+                     (count skipped)
+                     (count failed)))
     (doseq [{:keys [::confluence/page ::anom/message]} failed
-            :let [sfrp (paths/relative-path source-dir (get-in page [::md/source ::md/fp]))]] ;; sfrp == source-file-relative-path
+            :let [sfrp ;; source-file-relative-path
+                  (paths/relative-path source-dir (get-in page [::md/source ::md/fp]))]]
       (println "   🚨" (str sfrp) "\n"
                "    " message "\n"))))
 
 (defn -main
   [& [source-dir
       root-page-id
-      api-root-url
+      confluence-root-url ;; The root URL of the Confluence site, not the root of the REST API.
       username
       password :as _args]]
-  (let [client (make-client api-root-url username password)
+  (let [client (make-client confluence-root-url username password)
         _ (page-exists?! root-page-id client)]
     (-> (dir->page-tree (file source-dir) root-page-id)
         (replace-links source-dir)
@@ -45,8 +48,8 @@
 (comment
   (def source-dir "CHANGEME")
   (def root-page-id "CHANGEME")
-  (def api-root-url "CHANGEME")
+  (def confluence-root-url "CHANGEME")
   (def username "CHANGEME")
   (def password "CHANGEME")
 
-  (-main source-dir root-page-id api-root-url username password))
+  (-main source-dir root-page-id confluence-root-url username password))

--- a/src/md2c8e/confluence.clj
+++ b/src/md2c8e/confluence.clj
@@ -1,37 +1,166 @@
 (ns md2c8e.confluence
-  (:require [cognitect.anomalies :as anom]
-            [libpython-clj.require :refer [require-python]]
-            [libpython-clj.python :refer [py.] :as py]
+  (:require [clojure.string :as str]
+            [cognitect.anomalies :as anom]
+            [hato.client :as hc]
+            [md2c8e.anomalies :refer [anom fault]]
             [md2c8e.markdown :as md])
   (:import [java.io File]))
 
-(require-python 'atlassian)
+(def ^:private constants
+  {:connect-timeout 1000
+   :request-timeout 5000})
+
+(defn- api-url
+  [confluence-root-url first-path-segment & more-path-segments]
+  {:pre [(str/ends-with? confluence-root-url "/")]}
+  (str confluence-root-url
+       "rest/api/"
+       (->> (cons first-path-segment more-path-segments)
+            (map #(if (keyword? %) (name %) (str %)))
+            (str/join "/"))))
+
+(defn- ensure-trailing-slash
+  [s]
+  (if (str/ends-with? s "/")
+      s
+      (str s "/")))
 
 (defn make-client
-  [api-root-url username password]
-  (atlassian/Confluence api-root-url username password))
+  [confluence-root-url username password]
+  {::confluence-root-url confluence-root-url
+   ::url (partial api-url (ensure-trailing-slash confluence-root-url))
+   ::req-opts {:http-client (hc/build-http-client {:connect-timeout (:connect-timeout constants)
+                                                   :redirect-policy :never
+                                                   :version :http-1.1
+                                                   :cookie-policy :none})
+               :accept :json
+               :as :json
+               :basic-auth {:user username, :pass password}
+               :coerce :always
+               :timeout (:request-timeout constants)
+               :throw-exceptions? false}})
+
+(defn- successful?
+  [{status :status :as _response}]
+  (and (number? status)
+       (<= 200 status 206)))
+
+(defn- response->fault
+  "If the response represents an unsuccessful, error, or failed request, wraps it in an
+  ::anom/anomaly and returns it. Otherwise returns nil."
+  [res]
+  (when-not (successful? res)
+    (fault ::response res
+           ::anom/message (get-in res [:body :message]))))
+
+(defn- get-page-by-id
+  "Returns the page with the supplied ID, or an ::anom/anomaly.
+   The value of ::anom/category will vary depending on the circumstances:
+    * :not-found — the page simply doesn’t exist
+    * :fault — something went wrong"
+  [page-id {:keys [::req-opts ::url] :as _client}]
+  (let [res (hc/get (url :content page-id) (assoc req-opts :query-params {:expand "version,space"}))]
+    (case (:status res)
+      200 (:body res)
+      404 {::anom/category :not-found
+           ::anom/message (format "No page with ID %s exists" page-id)
+           ::page-id page-id
+           ::response res}
+      (response->fault res))))
 
 (defn page-exists?!
+  "Returns nil if the page exists; throws an Exception if it does not."
   [page-id client]
-  (let [res (py. client :get_page_by_id page-id)]
-    (when-not (and (= (type res) :pyobject)
-                   (get res "id"))
-      (throw (ex-info "Page does not exist!" {:page-id page-id :response res})))))
+  (when-let [res (anom (get-page-by-id page-id client))]
+    (throw (ex-info "Page does not exist!" res))))
+
+(defn- get-page-by-title
+  "Get the page with the supplied title, or nil if no such page is found."
+  [title space-key {:keys [::req-opts ::url] :as _client}]
+  (let [res (hc/get (url :content) (assoc req-opts :query-params {:spaceKey space-key
+                                                                  :title title
+                                                                  :expand "version"}))
+        results (get-in res [:body :results])]
+    (if (and (= (:status res) 200)
+             (<= (count results) 1))
+      (first results) ; will either return the page, if present, or nil
+      (response->fault res))))
+
+(defonce ^{:private true, :doc "Atom containing a map of page IDs to space keys, for caching."}
+  page-id->space-key
+  (atom {}))
+
+(defn- get-page-space-key
+  [page-id client]
+  (or (get @page-id->space-key page-id)
+      (let [res (get-page-by-id page-id client)
+            key (get-in res [:space :key])]
+        (or (anom res)
+            (swap! page-id->space-key assoc page-id key)))))
+
+(defn- update-page
+  [{id           :id
+    {vn :number} :version :as _current-page}
+   title
+   body
+   {:keys [::req-opts ::url] :as _client}]
+  {:pre [(number? vn)]}
+  (let [form-params {:version {:number (inc vn)}
+                     :type :page
+                     :title title
+                     :body {:storage {:value body, :representation :storage}}}
+        res (hc/put (url :content id)
+                    (assoc req-opts :content-type :json, :form-params form-params))]
+    (or (response->fault res)
+        (:body res))))
+
+(defn- create-page
+  [space-key parent-id title body {:keys [::req-opts ::url] :as _client}]
+  (let [form-params {:type :page
+                     :title title
+                     :space {:key space-key}
+                     :body {:storage {:value body, :representation :storage}}
+                     :ancestors [{:type :page :id parent-id}]}
+        res (hc/post (url :content)
+                     (assoc req-opts :content-type :json, :form-params form-params))]
+     (or (response->fault res)
+         (:body res))))
+
+(defn- enrich-err
+  [err source-file title body]
+  (let [tmpfile (File/createTempFile (or (and source-file (.getName source-file))
+                                         title)
+                                     ".xhtml")]
+    (spit tmpfile body)
+    (update err ::anom/message #(str % " --  XHTML body written to: " tmpfile))))
 
 (defn upsert
-  "If successful, returns the API response, which should include the String key 'id'.
-  If unsuccessful, returns an anomaly with the additional key ::response"
-  [page parent-id client]
-  (let [py-res (py. client :update_or_create parent-id (::title page) (::body page))
-        res (py/->jvm py-res)]
-    (if (contains? res "id")
-        res
-        (let [tmpfile (File/createTempFile (.getName (get-in page [::md/source ::md/fp])) ".xhtml")]
-          (spit tmpfile (::body page))
-          {::anom/category :fault
-           ::anom/message (str (or (get res "message")
-                                   "API request failed.")
-                               "\n  XHTML body written to: "
-                               tmpfile)
-           ::response res
-           ::page page}))))
+  "Useful for when we want to publish a page that may or may not have already been published; we
+  don’t know, and we don’t have an id for it.
+  If successful, returns a map with [::operation ::page]. ::page is a representation of the page
+  that was updated or created. Therefore it probably contains, among other keys, 'id' and 'version'.
+  If unsuccessful, returns an ::anom/anomaly with the additional key ::response."
+  [{:keys [::title ::body ::md/source] :as _page} parent-id client]
+  (let [space-key-res (get-page-space-key parent-id client)
+        space-key     (when-not (anom space-key-res)
+                        space-key-res)
+        get-res       (when space-key
+                        (get-page-by-title title space-key client))
+        page          (when-not (anom get-res)
+                        get-res)
+        op (cond (or (anom space-key-res) (anom get-res)) :none
+                 page                                     :update
+                 :else                                    :create)
+        op-res (case op
+                     :update (update-page page title body client)
+                     :create (create-page space-key parent-id title body client)
+                     :none)
+        err (or (anom space-key-res)
+                (anom get-res)
+                (anom op-res))]
+    (if err
+      (enrich-err err (::md/fp source) title body)
+      {::operation op
+       ::page op-res
+       ::versions {::prior (get-in page [:version :number])
+                   ::new (get-in op-res [:version :number])}})))

--- a/src/md2c8e/links.clj
+++ b/src/md2c8e/links.clj
@@ -8,7 +8,7 @@
 (defn- page?
   [v]
   (and (map? v)
-       (contains? v ::confluence/id))) ;; maybe use children? or a spec?
+       (contains? v ::confluence/page-id))) ;; maybe use children? or a spec?
 
 (defn- page-seq
   [page-tree]


### PR DESCRIPTION
This Python library was great for bootstrapping the tool, but ~the GIL is
making the publishing process way slow~.

Honestly, now that I think about it, I don’t think it’s *really* the
GIL. Because we could have used threading in Python to achieve
concurrency without parallelism, and that would have been sufficient,
since our publishing process spends most of its time waiting for
responses from Confluence.

However, while that would have been *technically* feasible, it would
have been too much work and it would have made the code hard to
maintain. That’s because we really need the concurrency to happen at a
higher level than the HTTP requests. We need a way for the core ns to
submit a ton of upserts simultaneously and block while waiting for the
results. And upserts are complex workflows involving multiple calls to
Confluence.

Now, yes, I could have added a Python ThreadPoolExecutor to the upsert
function, and have it return Python futures or something like that, I
guess. Or maybe Python futures wrapped in Clojure futures. But it would
have been awkward to implement, difficult to reason about, and I had
other reasons to remove the usage of Python via libpython-clj from the
project. Namely, I’m hoping to distribute this tool by compiling it to a
native binary using GraalVM. That’s a tricky enough prospect at this
juncture; it’d be effectively impossible (for me) with Python — and a
Python library (the Atlassian library) being required for the project.

Come to think of it, removing the dependency on Python and the Python
library will also make development and testing simpler and easier, as
there will be less requirements and steps involved in setting up the
environment.

Resolves #2
Refs #8