### PR TITLE
Use commonmark-java to convert Markdown to HTML

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   Kaocha:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-18.04]
+        os: [macos-10.15, ubuntu-18.04]
         java: [11, 13, 14]
         suite: [examples] # Our other suites (integration, properties) are empty — for now!
     runs-on: ${{ matrix.os }}

--- a/deps.edn
+++ b/deps.edn
@@ -11,6 +11,14 @@
               :tag "v0.5.0"
               :deps/manifest :deps}
         cheshire {:mvn/version "5.10.0"} ; used by hato. multiple deps + no deps.edn
+
+        ;; We use Atlassian’s commonmark-java library for converting Markdown documents to XHTML
+        com.atlassian.commonmark/commonmark                       {:mvn/version "0.15.0"}
+        com.atlassian.commonmark/commonmark-ext-autolink          {:mvn/version "0.15.0"}
+        com.atlassian.commonmark/commonmark-ext-gfm-strikethrough {:mvn/version "0.15.0"}
+        com.atlassian.commonmark/commonmark-ext-gfm-tables        {:mvn/version "0.15.0"}
+        com.atlassian.commonmark/commonmark-ext-heading-anchor    {:mvn/version "0.15.0"}
+        
         medley {:git/url "https://github.com/weavejester/medley"
                 :sha "6c79c4cce52b276daa3c2b6eaea78f96904bca56"
                 :tag "1.3.0"}}

--- a/src/md2c8e/markdown.clj
+++ b/src/md2c8e/markdown.clj
@@ -1,7 +1,12 @@
 (ns md2c8e.markdown
-  (:require [clojure.java.shell :as shell]
-            [clojure.string :as str])
-  (:import [java.io File]))
+  (:require [clojure.string :as str])
+  (:import [java.io File]
+           [org.commonmark.parser Parser]
+           [org.commonmark.renderer.html HtmlRenderer]
+           [org.commonmark.ext.autolink AutolinkExtension]
+           [org.commonmark.ext.heading.anchor HeadingAnchorExtension]
+           [org.commonmark.ext.gfm.strikethrough StrikethroughExtension]
+           [org.commonmark.ext.gfm.tables TablesExtension]))
 
 (def md-h1-pattern #"(?m)^# (.+)$")
 
@@ -22,11 +27,26 @@
   [^String md]
   (str/replace md md-h1-pattern ""))
 
+(def extensions
+  [(AutolinkExtension/create)
+   (HeadingAnchorExtension/create)
+   (StrikethroughExtension/create)
+   (TablesExtension/create)])
+
+(def parser
+  (-> (Parser/builder)
+      (.extensions extensions)
+      (.build)))
+
+(def renderer
+  (-> (HtmlRenderer/builder)
+      (.extensions extensions)
+      (.build)))
+
 (defn- markdown->html
   [md]
-  (let [res (shell/sh "pandoc" "--from=gfm" "--to=html4" :in md)]
-    ;; TODO: Handle errors! Check the results! :facepalm:
-    (:out res)))
+  (->> (.parse parser md)
+       (.render renderer)))
 
 (defn prep-content
   [md]

--- a/test/examples/md2c8e/markdown_test.clj
+++ b/test/examples/md2c8e/markdown_test.clj
@@ -1,0 +1,31 @@
+(ns md2c8e.markdown-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [are deftest]]
+            [md2c8e.markdown :as md]))
+
+(deftest test-markdown->html
+  (are [expected given] (= expected (#'md/markdown->html given))
+    "<p><em>Very</em> <strong>simple</strong> formatting</p>\n"
+    "*Very* **simple** formatting"
+
+    "<h2 id=\"header-titles-should-become-permalinks\">Header titles should become permalinks!</h2>\n"
+    "## Header titles should become permalinks!"
+
+    "<p><del>strikethrough</del></p>\n"
+    "~~strikethrough~~"
+    
+    "<p><a href=\"https://html5zombo.com/\">https://html5zombo.com/</a></p>\n"
+    "https://html5zombo.com/"
+    
+    (str "<table>\n<thead>\n<tr>\n<th>Foo</th>\n<th>Bar</th>\n</tr>\n</thead>\n"
+         "<tbody>\n<tr>\n<td>Baz</td>\n<td>Quux</td>\n</tr>\n</tbody>\n</table>\n")
+    (str/join "\n" ["Foo | Bar"
+                    "--- | ----"
+                    "Baz | Quux"])
+                    
+    "<details><summary>Pass through</summary>\n<p>Please!</p>\n"
+    "<details><summary>Pass through</summary>\n<p>Please!</p>"
+    
+    ;; See https://github.com/atlassian/commonmark-java/issues/172
+    "<section><ac:random>Some “random” “custom” tags</ac:random></section>\n"
+    "<section><ac:random>Some “random” “custom” tags</ac:random></section>"))


### PR DESCRIPTION
As I wrote in #28:

> It’d be better to use a JVM library because:
>
> * It reduces the number of “system” dependencies of the tool
>   * Which has myriad benefits
> * It’ll probably be faster.

Resolves #28