### PR TITLE
update to using api authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ clojure -Sdeps '{:deps {md2c8e {:git/url "https://github.com/FundingCircle/md2c8
         --root-page-id <int> \
         --site-root-url <url> \
         --username <str> \
-        --password <str>
+        --api-key <str>
 ```
 
 **NB:** make sure you replace the value of `:sha` (the `...`) with the SHA of the tip of the branch

--- a/src/md2c8e/cli.clj
+++ b/src/md2c8e/cli.clj
@@ -33,8 +33,8 @@
                "    " message "\n"))))
 
 (defn- publish-cmd
-  [{:keys [source-dir root-page-id site-root-url username password]}]
-  (let [client (make-client site-root-url username password)
+  [{:keys [source-dir root-page-id site-root-url username api-key]}]
+  (let [client (make-client site-root-url username api-key)
         threads 10] ;; TODO: Make threads a command-line option
     (as-> (dir->page-tree (file source-dir) root-page-id) pt
           (replace-links pt source-dir)
@@ -74,8 +74,8 @@
                           :short   "u"
                           :type    :string
                           :default :present}
-                         {:option  "password"
-                          :short   "p"
+                         {:option  "api-key"
+                          :short   "a"
                           :type    :string
                           :default :present}]
                   :runs publish-cmd}]})

--- a/src/md2c8e/confluence.clj
+++ b/src/md2c8e/confluence.clj
@@ -36,7 +36,7 @@
              {::anom/message msg}))))
 
 (defn make-client
-  [confluence-root-url username password]
+  [confluence-root-url username api-key]
   (let [urlf        (partial api-url (ensure-trailing-slash confluence-root-url))
         http-client (hc/build-http-client {:connect-timeout (:connect-timeout constants)
                                            :redirect-policy :never
@@ -45,7 +45,11 @@
         base-req-opts {:http-client http-client
                        :accept :json
                        :as :json
-                       :basic-auth {:user username, :pass password}
+                       :headers  {"Authorization" (->> api-key
+                                                       (str username ":")
+                                                       .getBytes
+                                                       (.encodeToString (java.util.Base64/getEncoder))
+                                                       (str "Basic "))}
                        :coerce :always
                        :timeout (:request-timeout constants)
                        :throw-exceptions? true}]


### PR DESCRIPTION
Confluence changed the api and now password authentication returns

Basic authentication with passwords is deprecated.  For more information, see: https://confluence.atlassian.com/cloud/deprecation-of-basic-authentication-with-passwords-for-jira-and-confluence-apis-972355348.html

This change replaces password authentication with api authentication as described above.

This change is authored by and contributed to the project md2c8e by
Neil McCallum <zugnush@gmail.com> who hereby certifies
each statement included in the project’s Developer Certificate of
Origin located at https://git.io/JfGcU